### PR TITLE
Use XPCF_DEFINE_COMPONENT_TRAITS macro

### DIFF
--- a/interfaces/SolARDescriptorsExtractorFromImagePopSift.h
+++ b/interfaces/SolARDescriptorsExtractorFromImagePopSift.h
@@ -116,12 +116,9 @@ private:
 }
 }
 
-template <> struct org::bcom::xpcf::ComponentTraits<SolAR::MODULES::POPSIFT::SolARDescriptorsExtractorFromImagePopSift>
-{
-
-    static constexpr const char * UUID = "{7fb2aace-a1b1-11eb-bcbc-0242ac130002}";
-    static constexpr const char * NAME = "SolARDescriptorsExtractorFromImagePopSift";
-    static constexpr const char * DESCRIPTION = "SolARDescriptorsExtractorFromImagePopSift implements SolAR::api::features::IImageMAtcher interface";
-};
+XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::POPSIFT::SolARDescriptorsExtractorFromImagePopSift,
+                             "7fb2aace-a1b1-11eb-bcbc-0242ac130002",
+                             "SolARDescriptorsExtractorFromImagePopSift",
+                             "SolARDescriptorsExtractorFromImagePopSift implements SolAR::api::features::IImageMAtcher interface")
 
 #endif // SolARDescriptorsExtractorFromImagePopSift_H

--- a/interfaces/SolARImageMatcherPopSift.h
+++ b/interfaces/SolARImageMatcherPopSift.h
@@ -115,12 +115,9 @@ private:
 }
 }
 
-template <> struct org::bcom::xpcf::ComponentTraits<SolAR::MODULES::POPSIFT::SolARImageMatcherPopSift>
-{
-
-    static constexpr const char * UUID = "{3baab95a-ad25-11eb-8529-0242ac130003}";
-    static constexpr const char * NAME = "SolARImageMatcherPopSift";
-    static constexpr const char * DESCRIPTION = "SolARImageMatcherPopSift implements SolAR::api::features::IImageMAtcher interface";
-};
+XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::POPSIFT::SolARImageMatcherPopSift,
+                             "3baab95a-ad25-11eb-8529-0242ac130003",
+                             "SolARImageMatcherPopSift",
+                             "SolARImageMatcherPopSift implements SolAR::api::features::IImageMAtcher interface")
 
 #endif // SolARImageMatcherPopSift_H


### PR DESCRIPTION
use XPCF_DEFINE_COMPONENT_TRAITS macro in order to avoid the definition of the traits in the xpcf namespace.